### PR TITLE
Fix/blueprint size conversion

### DIFF
--- a/src/classes/core.py
+++ b/src/classes/core.py
@@ -127,7 +127,7 @@ class Core():
 
                 used = prefix[lh][lw] - top - left + leftTop
                 if used == 0:
-                    result.append(Rect((i, j), (lh, lw)))
+                    result.append(Rect((i * UNIT, j * UNIT), (lh * UNIT, lw * UNIT)))
 
         return result
 


### PR DESCRIPTION
Only convert to 2x2 in core, keeping the interface consistent with Minecraft coordinate.