### PR TITLE
update nbt_builder

### DIFF
--- a/src/building_util/nbt_builder.py
+++ b/src/building_util/nbt_builder.py
@@ -1,8 +1,26 @@
+"""
+1. absPath = getNBTAbsPath(name, type, level) 
+    - get the absolute path of the nbt file.
+        - name, level can be found in src/building_util/building.py
+        - type can be found in src/building_util/building_info.py
+2. nbt_struct = nbt.NBTFile(absPath) 
+    - get the nbt structure.
+3. buildFromStructureNBT(nbt_struct, baseX, baseY, baseZ, biome) 
+    - build the structure
+    - biome default is "".
+"""
+
 from ..resource.biome_substitute import isChangeBlock, changeBlock
 import sys
+import os
 from nbt import nbt as nbt
 from typing import Tuple
 from gdpc import interface as INTF
+from src.building_util.building_info import CHALET, DESERT_BUILDING
+
+def getNBTAbsPath(name: str, type: int, level: int) -> str:
+    # Example: getNBTAbsPath("chalet", 1, 2) -> "...chalet1/level2.nbt"
+    return os.path.abspath(os.path.join(".", os.path.join("data", os.path.join("structures", os.path.join(name + f"{str(type)}", "level" + f"{str(level)}.nbt")))))
 
 
 def nbtToString(nbt_struct: nbt.TAG):
@@ -26,7 +44,7 @@ def nbtToString(nbt_struct: nbt.TAG):
             return '{}'.format(str(nbt_struct))
 
 
-def buildFromStructureNBT(nbt_struct: nbt.NBTFile, baseX: int, baseY: int, baseZ: int, biome: str, keep=False):
+def buildFromStructureNBT(nbt_struct: nbt.NBTFile, baseX: int, baseY: int, baseZ: int, biome: str = "", keep=False):
     # fix: isChangeBlock and changeBlock function - SubaRya
     palatte = nbt_struct["palette"]
     for blk in nbt_struct["blocks"]:
@@ -43,19 +61,16 @@ def buildFromStructureNBT(nbt_struct: nbt.NBTFile, baseX: int, baseY: int, baseZ
         if keep:
             option = "keep"
         # INTF.placeBlock(x + baseX, y + baseY, z + baseZ, blkName)
-        if ischangeBlock(biome) == True:
+        if isChangeBlock(biome) == True:
             blkName = changeBlock(biome, blkName)
         # print(blkName)
-        INTF.runCommand("/setblock {} {} {} {} {}".format(x +
-                        baseX, y + baseY, z + baseZ, blkName, option), 200)
+        INTF.runCommand("setblock {} {} {} {} {}".format(x +
+                        baseX, y + baseY, z + baseZ, blkName, option))
 
 
 def getStructureSizeNBT(nbt_struct: nbt.NBTFile) -> tuple[int, int, int]:
     size = nbt_struct["size"]
     return (int(str(size[0])), int(str(size[1])), int(str(size[2])))
 
-
-if __name__ == '__main__':
-    with open(sys.argv[1], 'rb') as f:
-        nbt_struct = nbt.NBTFile(fileobj=f)
-        buildFromStructureNBT(nbt_struct, 204, 4, 172, "")
+def getBuildingNBTDir(name:str, type:int, level:int):
+    return getNBTAbsPath(name, type, level)


### PR DESCRIPTION
Usage of nbt_builder
1. absPath = getNBTAbsPath(name, type, level) 
    - get the absolute path of the nbt file.
        - name, level can be found in src/building_util/building.py
        - type can be found in src/building_util/building_info.py
2. nbt_struct = nbt.NBTFile(absPath) 
    - get the nbt structure.
3. buildFromStructureNBT(nbt_struct, baseX, baseY, baseZ, biome) 
    - build the structure
    - biome default is "".